### PR TITLE
A lot of results were being hidden due to "repeat results being ommit…

### DIFF
--- a/recon/mixins/search.py
+++ b/recon/mixins/search.py
@@ -17,7 +17,7 @@ class GoogleWebMixin(object):
         num = 100
         page = start_page
         set_page = lambda x: (x - 1) * num
-        payload = {'q':query, 'start':set_page(page), 'num':num, 'complete':0}
+        payload = {'q':query, 'start':set_page(page), 'num':num, 'complete':0, 'filter':0}
         results = []
         self.verbose('Searching Google for: %s' % (query))
         while True:


### PR DESCRIPTION
…ed" on google.

This small fix tells Google not to worry about having to limit results shown and shows all available search results. Made the difference of 2 and 25 files shows when I changed this and used metacrawler on a site.